### PR TITLE
Char type specification

### DIFF
--- a/docs/lang/char.md
+++ b/docs/lang/char.md
@@ -1,0 +1,25 @@
+Character
+==============
+
+Types
+-----
+
+The character extension adds one new base type:
+
+    "char"
+
+Operations
+----------
+
+Comparison operators, which take two `char` values and produce a `bool`:
+
+- `ceq`
+- `clt`
+- `cle`
+- `cgt`
+- `cge`
+
+Printing
+--------
+
+The [core `print` operation](./core.md#miscellaneous) prints `char` values.

--- a/my-tests/char.bril
+++ b/my-tests/char.bril
@@ -1,0 +1,20 @@
+@main() {
+  c1: char = const 'a';
+  c2: char = const 'b';
+  print c1;
+  isequal: bool = ceq c1 c2;
+  print isequal;
+
+  tam: int = const 4;
+  pos: int = const 1;
+  charvec: ptr<char> = alloc tam;
+  charvec2: ptr<char> = ptradd charvec pos;
+  c: char = const 'o';
+  c2: char = const 'i';
+  store charvec c;
+  store charvec2 c2;
+  print c;
+  c: char = load charvec2;
+  print c;
+  free charvec;
+}

--- a/my-tests/float.bril
+++ b/my-tests/float.bril
@@ -1,0 +1,8 @@
+@main() {
+  i0: int = const 4.0;
+  print i0;
+  v0: float = const 9;
+  v1: float = const 3;
+  res: float = fdiv v0 v1;
+  print res;
+}

--- a/my-tests/float.json
+++ b/my-tests/float.json
@@ -1,0 +1,48 @@
+{
+  "functions": [
+    {
+      "instrs": [
+        {
+          "dest": "i0",
+          "op": "const",
+          "type": "int",
+          "value": 4.0
+        },
+        {
+          "args": [
+            "i0"
+          ],
+          "op": "print"
+        },
+        {
+          "dest": "v0",
+          "op": "const",
+          "type": "float",
+          "value": 9
+        },
+        {
+          "dest": "v1",
+          "op": "const",
+          "type": "float",
+          "value": 3
+        },
+        {
+          "args": [
+            "v0",
+            "v1"
+          ],
+          "dest": "res",
+          "op": "fdiv",
+          "type": "float"
+        },
+        {
+          "args": [
+            "res"
+          ],
+          "op": "print"
+        }
+      ],
+      "name": "main"
+    }
+  ]
+}


### PR DESCRIPTION
- Especificação do tipo Char em Bril: 24/10
    - Sintaxe do tipo novo
    - Funções a serem incorporadas
    - Analisar se devemos tornar o tipo Char compatível com Int (Usar os tipo Float como referência, em relação aos seus operadores e o tipo Int)
    - Testar operações de `int` com `float` e vice-versa.

![image](https://user-images.githubusercontent.com/49542480/197428421-be4046a4-5032-41cb-9b7a-5d78cb692609.png)
